### PR TITLE
Adjust height for tall keys

### DIFF
--- a/import_keyboard.py
+++ b/import_keyboard.py
@@ -225,6 +225,8 @@ def getKey(filePath):
                             key["h"] = prev["h"]
                         else:
                             key["h"] = 1
+                        if key["h"] > 1:
+                            key["h"] += (int(key["h"])-1) * 0.05
                         if "x2" in prev:
                             key["x2"] = prev["x2"]
                         if "y2" in prev:


### PR DESCRIPTION
The vertical dimension of keys is a bit off compared to the horizontal one. This is a workaround which effectively adds the “gap” length 0.05 to each row and fixes the appearance of (e.g.) the numpad tall keys