### PR TITLE
Fix labelSize if parsed as str

### DIFF
--- a/add_label.py
+++ b/add_label.py
@@ -48,6 +48,7 @@ def add(label, font, profile, labelPosition, labelMaterial, labelSize, keyX, key
     """Add label to a key"""
     context = bpy.context
     scn = context.scene
+    labelSize = int(labelSize)
     # add text
     new_label = bpy.data.curves.new(
         type="FONT", name="keylabel")


### PR DESCRIPTION
Had an import error where labelSize was not being parsed as int that resulted in `unsupported operand` for labelSize / 15.
Fixed by making sure it's cast as as an int before division.