### PR TITLE
Change modifier_apply call to gpencil_modifier_apply for Blender v2.9

### DIFF
--- a/add_label.py
+++ b/add_label.py
@@ -87,7 +87,7 @@ def add(label, font, profile, labelPosition, labelMaterial, labelSize, keyX, key
 
     new_label.data.extrude = 0.01
 
-    new_label.location = [boxLeft, boxTop, 2]
+    new_label.location = [boxLeft, boxTop, 0.75]
     new_label.rotation_euler[2] = pi
 
     helpers.add_object(scn, new_label)

--- a/add_label.py
+++ b/add_label.py
@@ -112,7 +112,7 @@ def add(label, font, profile, labelPosition, labelMaterial, labelSize, keyX, key
         new_label.modifiers["Remesh"].octree_depth = (
             4 if len(label_text) == 1 else 7)
         new_label.modifiers["Remesh"].use_remove_disconnected = False
-        bpy.ops.object.modifier_apply(
+        bpy.ops.object.gpencil_modifier_apply(
             apply_as='DATA', modifier="Remesh")
 
     helpers.unselect_all(scn)
@@ -131,7 +131,7 @@ def add(label, font, profile, labelPosition, labelMaterial, labelSize, keyX, key
         "Shrinkwrap"].use_negative_direction = True
     bpy.context.object.modifiers[
         "Shrinkwrap"].target = keyObject
-    bpy.ops.object.modifier_apply(
+    bpy.ops.object.gpencil_modifier_apply(
         apply_as='DATA', modifier="Shrinkwrap")
 
     # create clipping cube
@@ -150,7 +150,7 @@ def add(label, font, profile, labelPosition, labelMaterial, labelSize, keyX, key
     bpy.ops.object.modifier_add(type='BOOLEAN')
     bpy.context.object.modifiers["Boolean"].operation = 'INTERSECT'
     bpy.context.object.modifiers["Boolean"].object = scn.objects["clipCube"]
-    bpy.ops.object.modifier_apply(
+    bpy.ops.object.gpencil_modifier_apply(
         apply_as='DATA', modifier="Boolean")
     bpy.data.objects.remove(cube)
 

--- a/import_keyboard.py
+++ b/import_keyboard.py
@@ -840,6 +840,6 @@ def read(filepath):
     # remove all the template objects
     for object in defaultObjects:
         helpers.select_object(bpy.data.objects[object])
-    bpy.ops.object.delete()
+        bpy.ops.object.delete()
 
     bpy.context.window_manager.progress_end()


### PR DESCRIPTION
API appears to have changed: https://docs.blender.org/api/current/bpy.ops.object.html

I believe this should resolve issue #64, based on my own experience running into this and local testing only 😅  I was able to import without error and see the scene after making this change.